### PR TITLE
feature: build reusable form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query-devtools": "^5.75.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.56.3",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.0",
         "tailwindcss": "^4.1.5"
@@ -3511,6 +3512,21 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.56.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.3.tgz",
+      "integrity": "sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query-devtools": "^5.75.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.56.3",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.0",
     "tailwindcss": "^4.1.5"

--- a/src/hooks/useRegister.js
+++ b/src/hooks/useRegister.js
@@ -1,0 +1,8 @@
+import { useFormContext } from "react-hook-form";
+
+function useRegister(name, validation = {}) {
+    const {register} = useFormContext();
+    return {...register(name, validation)}
+}
+
+export default useRegister;

--- a/src/ui/Form.jsx
+++ b/src/ui/Form.jsx
@@ -1,0 +1,46 @@
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
+import useRegister from "../hooks/useRegister";
+
+function Form({ children }) {
+  const methods = useForm();
+  const { handleSubmit } = methods;
+
+  const onSubmit = data => console.log(data);
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-1">
+        {children}
+      </form>
+    </FormProvider>
+  );
+}
+
+function Input({ name, validation = {}, ...rest }) {
+  const rhfProps = useRegister(name, validation);
+
+  return <input {...rhfProps} {...rest} />;
+}
+
+function Label({ children }) {
+  return <>{children}</>;
+}
+
+function Error({ children, name }) {
+  const {
+    formState: { errors },
+  } = useFormContext();
+
+  return <>{errors[name] && children}</>;
+}
+
+function Submit({ children }) {
+  return <>{children}</>;
+}
+
+Form.Input = Input;
+Form.Label = Label;
+Form.Error = Error;
+Form.Submit = Submit;
+
+export default Form;


### PR DESCRIPTION
# Reusable Form Based On RHF Added

This is a reusable compound component that is fully customisable by its consumer. It has one custom hook and for now simply logs the result, but can be passed a CB for the onSubmit behaviour.